### PR TITLE
Added db_owner parameter to postgres setup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ galaxy_server_dir: "{{ galaxyFS_base_dir }}/galaxy-app"
 galaxy_db_dir: "{{ galaxyFS_base_dir }}/db"
 galaxy_db_port: 5930
 postgresql_bin_dir: /usr/lib/postgresql/9.3/bin
+
+db_owner: postgres

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,28 +3,44 @@
 
 - name: Initialize Galaxy database
   shell: "{{ postgresql_bin_dir }}/initdb -D {{ galaxy_db_dir }} creates={{ galaxy_db_dir }}/postgresql.conf"
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Set Postgres port number
   lineinfile: dest={{ galaxy_db_dir }}/postgresql.conf regexp='^#port\ =\ 5432' line='port = {{ galaxy_db_port }}'
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Check if PostgreSQL server is running
   stat: path={{ galaxy_db_dir }}/postmaster.pid
   register: postgres_running
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Restart Postgres
   shell: "{{ postgresql_bin_dir }}/pg_ctl -D {{ galaxy_db_dir }} -w -l /tmp/pgSQL.log restart"
   when: postgres_running.stat.exists
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Start Postgres
   shell: "{{ postgresql_bin_dir }}/pg_ctl -D {{ galaxy_db_dir }} -w -l /tmp/pgSQL.log start"
   when: not postgres_running.stat.exists
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Create galaxy role
   postgresql_user: port={{ galaxy_db_port }} name={{ galaxy_user_name }} role_attr_flags=CREATEDB,LOGIN
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Create galaxyftp role
   postgresql_user: port={{ galaxy_db_port }} name=galaxyftp role_attr_flags=LOGIN password={{ psql_galaxyftp_password }}
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 
 - name: Create galaxy database
   postgresql_db: port={{ galaxy_db_port }} name=galaxy owner={{ galaxy_user_name }}
+  sudo: yes
+  sudo_user: "{{ db_owner }}"
 


### PR DESCRIPTION
This pull adds the db_owner as a role variable, removing the need to specify the owner in the playbook.
